### PR TITLE
Update test-and-release workflow

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -31,7 +31,7 @@ jobs:
           node-version: '22.x'
           # Uncomment the following line if your adapter cannot be installed using 'npm ci'
           # install-command: 'npm install'
-          lint: true
+          lint: false
 
   # Runs adapter tests on all supported node versions and OSes
   adapter-tests:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,13 +5,18 @@ name: Test and Release
 on:
   push:
     branches:
-      - '*'
+      - "*"
     tags:
       # normal versions
-      - "v?[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+"
       # pre-releases
-      - "v?[0-9]+.[0-9]+.[0-9]+-**"
+      - "v[0-9]+.[0-9]+.[0-9]+-**"
   pull_request: {}
+
+# Cancel previous PR/branch runs when a new commit is pushed
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Performs quick checks before the expensive test runs
@@ -21,127 +26,67 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+      - uses: ioBroker/testing-action-check@v1
         with:
-          node-version: 22.x
-
-
-      - name: Install Dependencies
-        run: npm install
-
-#      - name: Perform a type check
-#        run: npm run check:ts
-#        env:
-#          CI: true
-      # - name: Lint TypeScript code
-      #   run: npm run lint
-#      - name: Test package files
-#        run: npm run test:package
-
+          node-version: '22.x'
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'
+          lint: true
 
   # Runs adapter tests on all supported node versions and OSes
   adapter-tests:
     if: contains(github.event.head_commit.message, '[skip ci]') == false
 
-    needs: [check-and-lint]
-
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x]
+        node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - uses: ioBroker/testing-action-adapter@v1
         with:
           node-version: ${{ matrix.node-version }}
+          os: ${{ matrix.os }}
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'
 
-      - name: Install Dependencies
-        run: npm install
+# TODO: To enable automatic npm releases, create a token on npmjs.org 
+# Enter this token as a GitHub secret (with name NPM_TOKEN) in the repository options
+# Then uncomment the following block:
 
-      - name: Run local tests
-        run: npm test
-#      - name: Run unit tests
-#        run: npm run test:unit
-#      - name: Run integration tests # (linux/osx)
-#        if: startsWith(runner.OS, 'windows') == false
-#        run: DEBUG=testing:* npm run test:integration
-#      - name: Run integration tests # (windows)
-#        if: startsWith(runner.OS, 'windows')
-#        run: set DEBUG=testing:* & npm run test:integration
-  # Deploys the final package to NPM
+ # Deploys the final package to NPM
+ deploy:
+   needs: [check-and-lint, adapter-tests]
 
-  deploy:
-    needs: [check-and-lint, adapter-tests]
+   # Trigger this step only when a commit on any branch is tagged with a version number
+   if: |
+     contains(github.event.head_commit.message, '[skip ci]') == false &&
+     github.event_name == 'push' &&
+     startsWith(github.ref, 'refs/tags/v')
 
-    # Trigger this step only when a commit on master is tagged with a version number
-    if: |
-      contains(github.event.head_commit.message, '[skip ci]') == false &&
-      github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
+   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
+   # Write permissions are required to create Github releases
+   permissions:
+     contents: write
 
-      - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22.x
+   steps:
+     - uses: ioBroker/testing-action-deploy@v1
+       with:
+         node-version: '22.x'
+         # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+         # install-command: 'npm install'
+         npm-token: ${{ secrets.NPM_TOKEN }}
+         github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract the version and commit body from the tag
-        id: extract_release
-        # The body may be multiline, therefore we need to escape some characters
-        run: |
-          VERSION="${{ github.ref }}"
-          VERSION=${VERSION##*/}
-          VERSION=${VERSION##*v}
-          echo "::set-output name=VERSION::$VERSION"
-          BODY=$(git show -s --format=%b)
-          BODY="${BODY//'%'/'%25'}"
-          BODY="${BODY//$'\n'/'%0A'}"
-          BODY="${BODY//$'\r'/'%0D'}"
-          echo "::set-output name=BODY::$BODY"
-
-      - name: Install Dependencies
-        run: npm install
-      #- name: Create a clean build
-      #  run: npm run build
-      - name: Publish package to npm
-        run: |
-          npm config set //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}
-          npm whoami
-          npm publish
-
-      - name: Create Github Release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release v${{ steps.extract_release.outputs.VERSION }}
-          draft: false
-          # Prerelease versions create pre-releases on GitHub
-          prerelease: ${{ contains(steps.extract_release.outputs.VERSION, '-') }}
-          body: ${{ steps.extract_release.outputs.BODY }}
-
-      - name: Notify Sentry.io about the release
-        run: |
-          npm i -g @sentry/cli
-          export SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          export SENTRY_URL=https://sentry.io
-          export SENTRY_ORG=rg-engineering
-          export SENTRY_PROJECT=iobroker_semp
-          export SENTRY_VERSION=iobroker.semp@${{ steps.extract_release.outputs.VERSION }}
-          sentry-cli releases new $SENTRY_VERSION
-          sentry-cli releases set-commits $SENTRY_VERSION --auto
-          sentry-cli releases finalize $SENTRY_VERSION
-
-        # Add the following line BEFORE finalize if sourcemap uploads are needed
-        # sentry-cli releases files $SENTRY_VERSION upload-sourcemaps build/    
-    
+         # When using Sentry for error reporting, Sentry can be informed about new releases
+         # To enable create a API-Token in Sentry (User settings, API keys)
+         # Enter this token as a GitHub secret (with name SENTRY_AUTH_TOKEN) in the repository options
+         # Then uncomment and customize the following block:
+#          sentry: true
+#          sentry-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
+#          sentry-project: "iobroker-template"
+#          sentry-version-prefix: "iobroker.template"
+#          # If your sentry project is linked to a GitHub repository, you can enable the following option
+#          # sentry-github-integration: true

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -55,35 +55,35 @@ jobs:
 # Enter this token as a GitHub secret (with name NPM_TOKEN) in the repository options
 # Then uncomment the following block:
 
- # Deploys the final package to NPM
- deploy:
-   needs: [check-and-lint, adapter-tests]
+  # Deploys the final package to NPM
+  deploy:
+    needs: [check-and-lint, adapter-tests]
 
-   # Trigger this step only when a commit on any branch is tagged with a version number
-   if: |
-     contains(github.event.head_commit.message, '[skip ci]') == false &&
-     github.event_name == 'push' &&
-     startsWith(github.ref, 'refs/tags/v')
+    # Trigger this step only when a commit on any branch is tagged with a version number
+    if: |
+      contains(github.event.head_commit.message, '[skip ci]') == false &&
+      github.event_name == 'push' &&
+      startsWith(github.ref, 'refs/tags/v')
 
-   runs-on: ubuntu-latest
+    runs-on: ubuntu-latest
 
-   # Write permissions are required to create Github releases
-   permissions:
-     contents: write
+    # Write permissions are required to create Github releases
+    permissions:
+      contents: write
 
-   steps:
-     - uses: ioBroker/testing-action-deploy@v1
-       with:
-         node-version: '22.x'
-         # Uncomment the following line if your adapter cannot be installed using 'npm ci'
-         # install-command: 'npm install'
-         npm-token: ${{ secrets.NPM_TOKEN }}
-         github-token: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: ioBroker/testing-action-deploy@v1
+        with:
+          node-version: '22.x'
+          # Uncomment the following line if your adapter cannot be installed using 'npm ci'
+          # install-command: 'npm install'
+          npm-token: ${{ secrets.NPM_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
-         # When using Sentry for error reporting, Sentry can be informed about new releases
-         # To enable create a API-Token in Sentry (User settings, API keys)
-         # Enter this token as a GitHub secret (with name SENTRY_AUTH_TOKEN) in the repository options
-         # Then uncomment and customize the following block:
+        # When using Sentry for error reporting, Sentry can be informed about new releases
+        # To enable create a API-Token in Sentry (User settings, API keys)
+        # Enter this token as a GitHub secret (with name SENTRY_AUTH_TOKEN) in the repository options
+        # Then uncomment and customize the following block:
 #          sentry: true
 #          sentry-token: ${{ secrets.SENTRY_AUTH_TOKEN }}
 #          sentry-project: "iobroker-template"


### PR DESCRIPTION
This PR update test-and-release workflow to current standard.

Please note that linting is currently deactivated. Please activate as soon as this repo is migrated to @iobroker/eslint-config and linting passes. Although running lint is NOT required it's a good practice. So please try to fix this even if its not considered blocking.

And please note that sentry handling is not active at the new workflow as you use some private sentry setup. So please migrate yourself. 

Running package test (ioBroker/testing-action-check@v1) and intergration test (ioBroker/testing-action-adapter@v1) is mandatory. Of course adding additional test is OK too.